### PR TITLE
[FIxed]Add config not to create files under test directory

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,11 @@ module Stackoverflow
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # rails generate ... 時の設定
+    config.generators do |g|
+      g.test_framework false  # テストディレクトリ配下は作成しない
+    end
+
   end
 end


### PR DESCRIPTION
#35 
ローカルでの実行ログ（`test_unit`に関するところが出力されていない）
```
~/Documents/workspace/StackOverFlow $ rails g controller sample
Running via Spring preloader in process 3367
Expected string default value for '--test-framework'; got false (boolean)
Expected string default value for '--test-framework'; got false (boolean)
Expected string default value for '--helper'; got true (boolean)
Expected string default value for '--assets'; got true (boolean)
      create  app/controllers/sample_controller.rb
      invoke  erb
      create    app/views/sample
Expected string default value for '--test-framework'; got false (boolean)
      invoke  helper
      create    app/helpers/sample_helper.rb
      invoke  assets
      invoke    coffee
      create      app/assets/javascripts/sample.coffee
      invoke    scss
      create      app/assets/stylesheets/sample.scss
~/Documents/workspace/StackOverFlow
```
参照：
http://qiita.com/ko_coon/items/3b5a8579c6447fcb222a
DIVERではassetとhelperも出力していないですが、それぞれ各機能で出力した方が各機能毎にメンテしやすいので出力したままにします。