### PR TITLE
[Fixed]タグ一覧ページレイアウト崩れ Issues/#66

### DIFF
--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -28,6 +28,13 @@
   border-bottom: none;
 }
 
+#tags-index-nav .active a{
+  border-radius: 0px;
+  margin-right: 0;
+  line-height: 1.3;
+  border-top: 2px solid #f69c55;
+}
+
 #tags-index-nav a{
   border-radius: 0px;
   margin-right: 0;

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -50,7 +50,32 @@
   padding: 5px 0px 5px 0px;
 }
 
-.tag-list {
+.tag-search-box form{
+  padding-left: 10px;
+}
+
+#tags-index-home.tab-pane {
+  display: none;
+}
+
+#tags-index-home.active {
+  display: block;
+}
+
+#tags-index-name.tab-pane {
+  display: none;
+}
+
+#tags-index-name.active {
+  display: block;
+}
+
+#tags-index-new.tab-pane {
+  display: none;
+}
+
+#tags-index-new.active {
+  display: block;
 }
 
 .tag-cell {

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -25,10 +25,12 @@
 #tags-index-nav {
   font-size: 12px;
   margin-left: auto;
+  border-bottom: none;
 }
 
 #tags-index-nav a{
   border-radius: 0px;
+  margin-right: 0;
 }
 
 .tags-page-description {

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -31,7 +31,7 @@
           <% @tags.each do |tag| %>
             <div class="wrapper col-lg-3 col-md-3 col-sm-5 col-xs-10">
               <div class="tag-cell">
-                
+
                 <div class="tag-count-set">
                  <%= link_to "#{tag.name}", questions_path(tag: tag.name), class: "post-tag"%>
                  &nbsp;

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -17,7 +17,7 @@
          質問に対して回答したりすることが容易になります。
        </p>
         <div class="tag-search-box">
-           <p>検索するタグを入力:</p>
+           <p>検索するタグを入力 :</p>
            <%= form_tag tags_path, method: "get" do %>
              <%= text_field_tag :search, params[:search] %>
              <% submit_tag "Search" %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -28,37 +28,37 @@
     <div class="tags-list">
       <div class="row">
         <div id="tags-index-home" class="tab-pane fade in active">
-
-                <% @tags.each do |tag| %>
-                <div class="wrapper col-lg-3 col-md-3 col-sm-5 col-xs-10">
-                  <div class="tag-cell">
-                    <div class="tag-count-set">
-                     <%= link_to "#{tag.name}", questions_path(tag: tag.name), class: "post-tag"%>
-                     &nbsp;
-                     <span class="item-multiplier">
-                       <span class="item-multiplier-x">&times;</span>&nbsp;
-                       <span class="item-multiplier-count"><%= tag.taggings_count %></span>
-                     </span>
-                    </div>
-                    <div class="excerpt">
-
-                    </div>
-
-                    <div class="question-counter-set">
-                      <%= @questions_one_week.tagged_with(tag).count %>件の今週の質問数,
-                      <%= @questions_one_month.tagged_with(tag).count %>件の今月の質問数
-                    </div>
-
-                  </div>
+          <% @tags.each do |tag| %>
+            <div class="wrapper col-lg-3 col-md-3 col-sm-5 col-xs-10">
+              <div class="tag-cell">
+                
+                <div class="tag-count-set">
+                 <%= link_to "#{tag.name}", questions_path(tag: tag.name), class: "post-tag"%>
+                 &nbsp;
+                 <span class="item-multiplier">
+                   <span class="item-multiplier-x">&times;</span>&nbsp;
+                   <span class="item-multiplier-count"><%= tag.taggings_count %></span>
+                 </span>
                 </div>
-                <% end %>
 
+                <div class="excerpt">
+                </div>
+
+                <div class="question-counter-set">
+                  <%= @questions_one_week.tagged_with(tag).count %>件の今週の質問数,
+                  <%= @questions_one_month.tagged_with(tag).count %>件の今月の質問数
+                </div>
+
+              </div>
+            </div>
+          <% end %>
         </div>
 
         <div id="tags-index-name" class="tab-pane fade">
           <% @tags_name.each do |tag| %>
           <div class="wrapper col-lg-3 col-md-3 col-sm-5 col-xs-10">
             <div class="tag-cell">
+
               <div class="tag-count-set">
                <%= link_to "#{tag.name}", questions_path(tag: tag.name), class: "post-tag"%>
                &nbsp;
@@ -67,8 +67,8 @@
                  <span class="item-multiplier-count"><%= tag.taggings_count %></span>
                </span>
               </div>
-              <div class="excerpt">
 
+              <div class="excerpt">
               </div>
 
               <div class="question-counter-set">
@@ -85,6 +85,7 @@
           <% @tags_new.each do |tag| %>
           <div class="wrapper col-lg-3 col-md-3 col-sm-5 col-xs-10">
             <div class="tag-cell">
+
               <div class="tag-count-set">
                <%= link_to "#{tag.name}", questions_path(tag: tag.name), class: "post-tag"%>
                &nbsp;
@@ -93,8 +94,8 @@
                  <span class="item-multiplier-count"><%= tag.taggings_count %></span>
                </span>
               </div>
-              <div class="excerpt">
 
+              <div class="excerpt">
               </div>
 
               <div class="tags-created-at">


### PR DESCRIPTION
#66
【修正】
・タブ内表示のレイアウト崩れを修正しました。
        activeでないクラスをdisplay: none;で非表示にした。
・タブ部の一部が太くなっているのを修正しました。

【向上】
・アクティブなタブの上部にオレンジ色を付けた。