### PR TITLE
【Fixed】質問詳細画面のマークダウン対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,4 @@ gem 'gon'
 
 # マークダウン用gem
 gem 'marked-rails'
+gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     rdoc (4.3.0)
+    redcarpet (3.4.0)
     request_store (1.3.2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -267,6 +268,7 @@ DEPENDENCIES
   pry-rails
   rails (= 4.2.3)
   rails_12factor
+  redcarpet
   rmagick
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/javascripts/questions.coffee
+++ b/app/assets/javascripts/questions.coffee
@@ -1,4 +1,4 @@
-$ ->
+$(document).on ->
   replaceMarkdown = (elm) ->
     v = undefined
     old = elm.value

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -1,2 +1,5 @@
 module AnswersHelper
+  def answer_time(answer)
+    '回答日時:' + answer.updated_at.strftime('%y年%m月%d日 %H:%M')
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,24 @@ module ApplicationHelper
     end
     image_tag(img_url, alt: user.name, size: '32x32')
   end
+
+  def markdown(text)
+    render_options = {
+      filter_html: false,
+      hard_wrap: true
+    }
+    renderer = Redcarpet::Render::HTML.new(render_options)
+
+    extensions = {
+      no_intra_emphasis: true,
+      tables: true,
+      fenced_code_blocks: true,
+      autolink: true,
+      strikethrough: true,
+      lax_spacing: true,
+      space_after_headers: true,
+      superscript: true,
+    }
+    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
+  end
 end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -1,2 +1,5 @@
 module QuestionsHelper
+  def question_time(question)
+    '質問日時:' + question.created_at.strftime('%y年%m月%d日 %H:%M')
+  end
 end

--- a/app/views/answers/_index.html.erb
+++ b/app/views/answers/_index.html.erb
@@ -13,7 +13,7 @@
       </td>
       <td class="postcell">
         <div class="post-text">
-          <p><%= simple_format answer.content %></p>
+          <%= markdown answer.content %>
         </div>
         <table class="answer-footer">
           <tbody>
@@ -28,7 +28,7 @@
               </td>
               <td class="post-signature">
                 <div class="user-info">
-                  <div class="user-action-time">回答日時:<%= answer.updated_at.strftime('%y年%m月%d日 %H:%M') %></div>
+                  <div class="user-action-time"><%= answer_time(answer) %></div>
                   <div class="user-avatar">
                     <%= profile_img_32(answer.user) %>
                   </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -29,7 +29,7 @@
               </td>
               <td class="postcell">
                 <div class="post-text">
-                  <p><%= simple_format @question.content %></p>
+                  <%= markdown @question.content %>
                 </div>
                 <div class="post-taglist">
                   <!-- タグ表示 -->
@@ -48,7 +48,7 @@
                       </td>
                       <td class="post-signature">
                         <div class="user-info">
-                          <div class="user-action-time">質問日時:<%= @question.created_at.strftime('%y年%m月%d日 %H:%M') %></div>
+                          <div class="user-action-time"><%= question_time(@question) %></div>
                           <div class="user-avatar">
                             <%= profile_img_32(@question.user) %>
                           </div>


### PR DESCRIPTION
#75 
- Gemfileにredcarpetを追加
- 質問詳細画面の質問・回答のマークダウンを表示するメソッドをヘルパーに追加
- 質問投稿画面に初遷移時、マークダウンプレビューが効かなかったのを修正
- 質問日時・回答日時がviewにベタ書きだったのでヘルパーに切り出し