### PR TITLE
【FIxed】answerのN+1問題

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -17,12 +17,12 @@ class QuestionsController < ApplicationController
     else
       @questions = Question.all
     end
-    @questions = @questions.includes(:tags)
+    @questions = @questions.includes(:tags).order(updated_at: :DESC)
   end
 
   def show
     @answer = @question.answers.build
-    @answers = @question.answers
+    @answers = @question.answers.includes(:user).order(:created_at)
   end
 
   def new


### PR DESCRIPTION
#94 
* 質問詳細画面表示時のN+1問題を解消
* 質問一覧は更新時間が最新順、質問詳細の回答一覧は作成時間が古い順に表示されるようorderを追加
